### PR TITLE
fix: Exclude okhttp-digest

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,6 +7,10 @@ repositories {
 }
 
 dependencies {
-  implementation "org.asciidoctor:asciidoctor-gradle-jvm-slides:3.3.2"
-  implementation "org.asciidoctor:asciidoctor-gradle-slides-export:3.3.2"
+  implementation("org.asciidoctor:asciidoctor-gradle-jvm-slides:3.3.2") {
+    exclude(group: "com.burgstaller", module: "okhttp-digest")
+  }
+  implementation("org.asciidoctor:asciidoctor-gradle-slides-export:3.3.2") {
+    exclude(group: "com.burgstaller", module: "okhttp-digest")
+  }
 }


### PR DESCRIPTION
It doesn't appear to be on central or plugin portal.