### PR TITLE
chore: Run one build per branch

### DIFF
--- a/.github/workflows/build-slidedecks.yml
+++ b/.github/workflows/build-slidedecks.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [ "*" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should prevent conflicts on publishing.
