### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-slidedecks.yml
+++ b/.github/workflows/build-slidedecks.yml
@@ -12,6 +12,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/rahulsom/nflx-slidedecks/security/code-scanning/1](https://github.com/rahulsom/nflx-slidedecks/security/code-scanning/1)

To fix the problem, you should explicitly set a `permissions` block in the workflow, either globally (at the root) or within each job. Since this workflow only has a single job (`build`), you can add the `permissions:` key at the job level. For workflows that deploy to GitHub Pages using the JamesIves/github-pages-deploy-action, the minimal required permissions are `contents: write` (to push the built pages). Steps that perform builds, installs, etc., only need read access, so restricting to just `contents: write` (or even more narrowly if you don't commit code changes) is ideal. The recommended change is to add (indentation matters):

```
permissions:
  contents: write
```

immediately after the job definition (`build:` line 14), before any other job-level keys (such as `runs-on`). No further imports or additional configuration are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
