### PR TITLE
chore(renovate): Enable lockFileMaintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,11 @@
     "config:recommended"
   ],
   "automerge": false,
+  "npm": {
+    "lockFileMaintenance": {
+      "enabled": true
+    }
+  },
   "postUpdateOptions": [
     "npmInstallTwice"
   ]


### PR DESCRIPTION
This should help with 'npm ci' failing on PRs
