### PR TITLE
fix(renovate): use puppeteerrc to skip browser download during npm install

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,10 +4,8 @@
     "config:recommended"
   ],
   "automerge": false,
-  "npm": {
-    "lockFileMaintenance": {
-      "enabled": true
-    }
+  "lockFileMaintenance": {
+    "enabled": true
   },
   "postUpdateOptions": [
     "npmInstallTwice"

--- a/.github/workflows/build-slidedecks.yml
+++ b/.github/workflows/build-slidedecks.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.puppeteer_cache
-      PUPPETEER_BROWSER_REVISION: '1135561'
 
     steps:
     - uses: actions/checkout@v7
@@ -32,7 +31,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ${{ env.PUPPETEER_CACHE_DIR }}
-        key: ${{ runner.os }}-puppeteer-${{ env.PUPPETEER_BROWSER_REVISION }}
+        key: ${{ runner.os }}-puppeteer-${{ hashFiles('package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-puppeteer-
 
@@ -44,6 +43,9 @@ jobs:
 
     - name: Install npm dependencies
       run: npm ci
+
+    - name: Download puppeteer browser
+      run: npx puppeteer browsers install chrome
 
     - name: Install font
       run: |

--- a/.puppeteerrc.cjs
+++ b/.puppeteerrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  skipDownload: true,
+};


### PR DESCRIPTION
## Summary

The `renovate/artifacts` check was failing because puppeteer's postinstall script tried to download a Chromium binary when Renovate ran `npm install` to regenerate `package-lock.json`, causing the lock file update to fail and CI to break with mismatched dependencies.

- Add `.puppeteerrc.cjs` with `skipDownload: true` so `npm install` never triggers a browser download (fixes Renovate lock file updates and avoids the issue locally too)
- Add an explicit `npx puppeteer browsers install chrome` step in CI so the browser is still downloaded and cached there
- Cache the puppeteer browser by `package-lock.json` hash instead of a hardcoded revision, so the cache key automatically updates when dependencies change
- Remove `PUPPETEER_BROWSER_REVISION` env var (it was pinning a specific Chrome build; superseded by the per-lock-file cache key)
- Move `lockFileMaintenance` to the top level of `renovate.json` (it was misplaced under `"npm"` and was being ignored)