### PR TITLE
fix: remove invalid packageManager field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,5 @@
     "vega-cli": "^6.0.0",
     "vega-embed": "^7.0.0",
     "vega-lite": "^6.0.0"
-  },
-  "packageManager": "npm@24.8.0"
+  }
 }


### PR DESCRIPTION
## Summary

- `package.json` had `"packageManager": "npm@24.8.0"` — a node version number accidentally placed in an npm field. `npm@24.8.0` does not exist on the registry.
- Renovate reads this field and tries to `install-tool npm 24.8.0` before running `npm install` to regenerate `package-lock.json`. This fails with `notarget`, leaving the lock file un-updated and the `renovate/artifacts` check red.
- Removing the field lets Renovate use the npm version that ships with the pinned node version in the workflow.