### PR TITLE
fix(pdf): generate portrait PDFs with correct colors and notes layout

### DIFF
--- a/scripts/export-pdf.ts
+++ b/scripts/export-pdf.ts
@@ -16,7 +16,12 @@ interface FileServer {
   url: string;
 }
 
-// Simple HTTP server for serving files during PDF export
+interface SlideInfo {
+  h: number;
+  v: number;
+  notesHtml: string;
+}
+
 function createFileServer(rootPath: string, port: number = 0): Promise<FileServer> {
   const mimeTypes: Record<string, string> = {
     '.html': 'text/html',
@@ -34,10 +39,9 @@ function createFileServer(rootPath: string, port: number = 0): Promise<FileServe
   };
 
   const server = createServer((req, res) => {
-    // Parse URL and remove query parameters for file lookup
     const urlPath = req.url?.split('?')[0] || '/';
     let filePath = path.join(rootPath, urlPath === '/' ? 'index.html' : urlPath);
-    
+
     if (!existsSync(filePath)) {
       res.writeHead(404);
       res.end('File not found');
@@ -46,10 +50,10 @@ function createFileServer(rootPath: string, port: number = 0): Promise<FileServe
 
     const ext = extname(filePath);
     const contentType = mimeTypes[ext] || 'application/octet-stream';
-    
+
     try {
       const content = readFileSync(filePath);
-      res.writeHead(200, { 
+      res.writeHead(200, {
         'Content-Type': contentType,
         'Cache-Control': 'no-cache'
       });
@@ -69,101 +73,209 @@ function createFileServer(rootPath: string, port: number = 0): Promise<FileServe
   });
 }
 
+function buildPortraitPdfHtml(screenshots: string[], slides: SlideInfo[]): string {
+  const pages = screenshots.map((screenshot, i) => {
+    const notes = slides[i]?.notesHtml || '';
+    return `
+    <div class="page">
+      <div class="slide-image">
+        <img src="data:image/jpeg;base64,${screenshot}" alt="Slide ${i + 1}">
+      </div>
+      <div class="notes-section">
+        <div class="notes-header">Notes</div>
+        <div class="notes-content">${notes}</div>
+      </div>
+    </div>`;
+  }).join('\n');
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+  @page { size: A4 portrait; margin: 0; }
+  * { box-sizing: border-box; }
+  body { margin: 0; padding: 0; font-family: Helvetica, Arial, sans-serif; }
+  .page {
+    width: 210mm;
+    height: 297mm;
+    display: flex;
+    flex-direction: column;
+    page-break-after: always;
+  }
+  .slide-image {
+    height: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #fff;
+    overflow: hidden;
+  }
+  .slide-image img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+  }
+  .notes-section {
+    height: 50%;
+    padding: 8mm 10mm;
+    overflow: hidden;
+    background: #fff;
+    border-top: 2px solid #e60010;
+  }
+  .notes-header {
+    font-size: 9pt;
+    font-weight: bold;
+    color: #e60010;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 4mm;
+  }
+  .notes-content {
+    font-size: 10pt;
+    line-height: 1.5;
+    color: #333;
+  }
+  .notes-content p { margin: 0 0 0.4em; }
+  .notes-content .paragraph { margin: 0 0 0.4em; }
+  .notes-content .paragraph p { margin: 0; }
+  .notes-content ul, .notes-content ol { margin: 0 0 0.4em; padding-left: 1.2em; }
+  .notes-content li { margin-bottom: 0.2em; }
+</style>
+</head>
+<body>
+${pages}
+</body>
+</html>`;
+}
+
 async function exportPDF(presentationName: string): Promise<void> {
   console.log(`Exporting PDF for presentation: ${presentationName}`);
-  
+
   if (!PRESENTATIONS[presentationName]) {
     console.error(`Unknown presentation: ${presentationName}`);
     process.exit(1);
   }
-  
+
   const presentationDir = path.join(ROOT_DIR, presentationName);
   const buildDir = path.join(presentationDir, 'build', 'docs', 'asciidocRevealJs');
   const exportDir = path.join(presentationDir, 'build', 'docs', 'asciidocRevealJsExport');
   const htmlFile = path.join(buildDir, 'index.html');
   const pdfFile = path.join(exportDir, 'index.pdf');
-  
-  // Check if HTML file exists
+
   if (!fs.existsSync(htmlFile)) {
     console.error(`HTML file not found: ${htmlFile}`);
     console.error('Please build the presentation first with: npm run build:presentation');
     process.exit(1);
   }
-  
-  // Ensure export directory exists
+
   await fs.ensureDir(exportDir);
-  
+
   console.log('Starting HTTP server for assets...');
-  
-  // Start HTTP server to serve files
-  const { server, port, url } = await createFileServer(buildDir);
+  const { server, url } = await createFileServer(buildDir);
   console.log(`HTTP server started on: ${url}`);
-  
-  console.log('Starting Puppeteer...');
-  
+
   let browser: Browser | undefined;
   try {
-    // Try different launch configurations based on environment
     let launchOptions: LaunchOptions = {
-      headless: true, // Try old headless mode
+      headless: true,
       args: [
         '--no-sandbox',
         '--disable-setuid-sandbox',
-        '--disable-dev-shm-usage'
+        '--disable-dev-shm-usage',
+        '--force-color-profile=srgb'
       ]
     };
 
-    // Check if we're on macOS and try alternative config
     if (process.platform === 'darwin') {
       launchOptions = {
         headless: true,
-        args: ['--no-sandbox'],
+        args: ['--no-sandbox', '--force-color-profile=srgb'],
         ignoreDefaultArgs: ['--disable-extensions']
       };
     }
 
     browser = await puppeteer.launch(launchOptions);
-    
-    const page = await browser.newPage();
-    
-    // Set viewport for consistent rendering
-    await page.setViewport({
-      width: 1600,
-      height: 1050,
-      deviceScaleFactor: 1
-    });
-    
-    console.log(`Loading presentation from: ${url}/index.html?print-pdf`);
-    
-    // Load the HTML file via HTTP server with print-pdf parameter
-    await page.goto(`${url}/index.html?print-pdf`, {
+
+    // --- Phase 1: Screenshot each slide ---
+    const slidePage = await browser.newPage();
+    await slidePage.setViewport({ width: 1600, height: 900, deviceScaleFactor: 1 });
+
+    console.log(`Loading presentation from: ${url}/index.html`);
+    await slidePage.goto(`${url}/index.html`, {
       waitUntil: ['load', 'domcontentloaded'],
       timeout: 30000
     });
-    
-    // Wait for RevealJS and slides to load
-    console.log('Waiting for presentation to load...');
-    await page.waitForFunction('typeof Reveal !== "undefined"', { timeout: 15000 });
-    await page.waitForFunction(() => {
+
+    await slidePage.waitForFunction('typeof Reveal !== "undefined"', { timeout: 15000 });
+    await slidePage.waitForFunction(() => {
       return document.querySelectorAll('.reveal .slides section').length > 0;
     }, { timeout: 10000 });
-    
-    // Wait for images and fonts to load
-    await new Promise(resolve => setTimeout(resolve, 5000));
-    
-    console.log('Generating PDF...');
-    
-    // Get slide count for verification
-    const slideCount = await page.evaluate(() => {
-      return document.querySelectorAll('.reveal .slides section').length;
+
+    // Disable slide transitions and hide RevealJS UI chrome for clean screenshots
+    await slidePage.addStyleTag({
+      content: [
+        '.reveal .slides section { transition: none !important; animation: none !important; }',
+        '.reveal .controls { display: none !important; }',
+        '.reveal .progress { display: none !important; }',
+        '.reveal .slide-number { display: none !important; }',
+        '.reveal .speaker-notes { display: none !important; }',
+      ].join('\n')
     });
-    console.log(`Found ${slideCount} slides to export`);
-    
-    // Generate PDF with settings optimized for slide presentation
-    await page.pdf({
+
+    console.log('Waiting for fonts and images to load...');
+    await new Promise(resolve => setTimeout(resolve, 5000));
+
+    // Collect slide coordinates and speaker notes from the DOM
+    const slideInfos: SlideInfo[] = await slidePage.evaluate(() => {
+      const result: Array<{ h: number; v: number; notesHtml: string }> = [];
+      document.querySelectorAll('.reveal .slides > section').forEach((hSlide, h) => {
+        const vSlides = hSlide.querySelectorAll(':scope > section');
+        if (vSlides.length === 0) {
+          const notes = hSlide.querySelector('aside.notes');
+          result.push({ h, v: 0, notesHtml: notes ? notes.innerHTML : '' });
+        } else {
+          vSlides.forEach((vSlide, v) => {
+            const notes = vSlide.querySelector('aside.notes');
+            result.push({ h, v, notesHtml: notes ? notes.innerHTML : '' });
+          });
+        }
+      });
+      return result;
+    });
+
+    console.log(`Found ${slideInfos.length} slides to export`);
+
+    const screenshots: string[] = [];
+    for (let i = 0; i < slideInfos.length; i++) {
+      const { h, v } = slideInfos[i];
+      await slidePage.evaluate(({ h, v }: { h: number; v: number }) => {
+        (window as any).Reveal.slide(h, v);
+      }, { h, v });
+
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      const screenshot = await slidePage.screenshot({ encoding: 'base64', type: 'jpeg', quality: 85 });
+      screenshots.push(screenshot as string);
+
+      if ((i + 1) % 10 === 0 || i + 1 === slideInfos.length) {
+        console.log(`Screenshotted ${i + 1}/${slideInfos.length} slides`);
+      }
+    }
+
+    await slidePage.close();
+
+    // --- Phase 2: Compose portrait PDF with slide image (top) + speaker notes (bottom) ---
+    console.log('Generating portrait PDF...');
+    const pdfHtml = buildPortraitPdfHtml(screenshots, slideInfos);
+
+    const pdfPage = await browser.newPage();
+    await pdfPage.setContent(pdfHtml, { waitUntil: 'load' });
+
+    await pdfPage.pdf({
       path: pdfFile,
       format: 'A4',
-      landscape: true,
+      landscape: false,
       printBackground: true,
       margin: {
         top: '0px',
@@ -173,9 +285,9 @@ async function exportPDF(presentationName: string): Promise<void> {
       },
       preferCSSPageSize: true
     });
-    
+
     console.log(`✓ PDF exported to: ${pdfFile}`);
-    
+
   } catch (error) {
     console.error('Failed to export PDF:', error);
     process.exit(1);
@@ -183,21 +295,20 @@ async function exportPDF(presentationName: string): Promise<void> {
     if (browser) {
       await browser.close();
     }
-    // Close HTTP server
     server.close();
   }
 }
 
 async function main(): Promise<void> {
   const presentationName = process.argv[2];
-  
+
   if (!presentationName) {
     console.error('Usage: tsx scripts/export-pdf.ts <presentation-name>');
     console.error('Available presentations:');
     Object.keys(PRESENTATIONS).forEach(name => console.error(`  - ${name}`));
     process.exit(1);
   }
-  
+
   await exportPDF(presentationName);
 }
 

--- a/stylesheet/src/main/sass/netflix.scss
+++ b/stylesheet/src/main/sass/netflix.scss
@@ -1,6 +1,20 @@
 @import "../netflix-sans.scss";
 @import "white.scss";
 
+// Bridge the camelCase SCSS variables defined in white.scss to the hyphenated
+// CSS custom properties emitted by settings.scss, overriding the dark defaults.
+:root {
+  --r-background: #{$backgroundColor};
+  --r-background-color: #{$backgroundColor};
+  --r-main-color: #{$mainColor};
+  --r-heading-color: #{$headingColor};
+  --r-link-color: #{$linkColor};
+  --r-link-color-hover: #{$linkColorHover};
+  --r-selection-background-color: #{$selectionBackgroundColor};
+  --r-overlay-element-bg-color: #{$overlayElementBgColor};
+  --r-overlay-element-fg-color: #{$overlayElementFgColor};
+}
+
 ul.none {
   list-style: none;
 }
@@ -73,7 +87,12 @@ ul.none {
       margin: 0;
       padding: 5px;
       right: 0;
+      display: none;
     }
+  }
+
+  section.present .attribution p {
+    display: block;
   }
 
 }


### PR DESCRIPTION
## Summary

- Rewrote `export-pdf.ts` to screenshot each slide individually, then compose a portrait A4 PDF with the slide image on the top half and speaker notes on the bottom half (replacing the old landscape `?print-pdf` approach)
- Fixed attribution bleed: `.attribution p` is now hidden by default via `display: none` and only shown on `section.present`, preventing fixed-position elements from appearing across all slides during screenshotting
- Fixed slide colors: added a `:root` block in `netflix.scss` that bridges the white theme's camelCase SCSS variables (`$backgroundColor`, `$mainColor`, etc.) to the CSS custom properties used by RevealJS 6.x (`--r-background`, `--r-main-color`, etc.), overriding the dark defaults emitted by `settings.scss`

## Verification

Rendered the first several pages of the generated PDF with `pdftoppm` and confirmed:
- Portrait A4 layout with slide screenshot on top, speaker notes below
- White backgrounds and dark text (previously rendered as gray/dark)
- No yellow attribution bar bleeding across non-background-image slides
- No black letterbox bars around slide images