### PR TITLE
fix(renovate): group asciidoctor packages and enforce lockfile updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,11 +3,21 @@
   "extends": [
     "config:recommended"
   ],
+  "rangeStrategy": "update-lockfile",
   "automerge": false,
   "lockFileMaintenance": {
     "enabled": true
   },
   "postUpdateOptions": [
     "npmInstallTwice"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "@asciidoctor/core",
+        "asciidoctor-kroki"
+      ],
+      "groupName": "asciidoctor packages"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

* Configured `packageRules` in [.github/renovate.json](file:///.github/renovate.json) to group `@asciidoctor/core` and `asciidoctor-kroki` together under `asciidoctor packages`.
* Set `rangeStrategy: "update-lockfile"` to ensure Renovate always updates `package-lock.json` alongside `package.json`.

### Rationale
Upgrading `@asciidoctor/core` to 4.x breaks when updated in isolation because `asciidoctor-kroki@0.18.1` specifies a peer dependency constraint of `@asciidoctor/core@>=2.2 <4.0`. Grouping these dependencies ensures Renovate upgrades both packages to mutually compatible versions simultaneously, preventing lockfile generation failures.